### PR TITLE
feat: add clickable application link to chatbot

### DIFF
--- a/python-llm-service/application.py
+++ b/python-llm-service/application.py
@@ -20,7 +20,7 @@ def is_housing_related(question: str) -> bool:
     """
     Checks if the question is related to housing.
     """
-    housing_keywords = ["listings", "housing", "apartments", "rentals", "home", "properties", "houses", "rent"]
+    housing_keywords = ["listings", "listing", "housing", "housing", "apartments", "apartment", "rentals", "rental", "home", "property", "properties", "houses", "rent"]
     return any(keyword in question.lower() for keyword in housing_keywords)
 
 def get_housing_response(question: str) -> str:

--- a/python-llm-service/application.py
+++ b/python-llm-service/application.py
@@ -1,0 +1,32 @@
+def get_application_info() -> str:
+    """
+    Returns information about the housing application process.
+    """
+    return "To apply for housing, please visit our application portal at https://bloom.exygy.dev/applications/start/choose-language?listingId=ca935750-769d-4062-a0b7-d52005c3aa74"
+
+def format_application_response() -> str:
+    """
+    Formats the application response with the application link.
+    """
+    application_info = get_application_info()
+    # Convert the plain URL to a Markdown link
+    application_info = application_info.replace(
+        "https://bloom.exygy.dev/applications/start/choose-language?listingId=ca935750-769d-4062-a0b7-d52005c3aa74",
+        "[Apply for Housing](https://bloom.exygy.dev/applications/start/choose-language?listingId=ca935750-769d-4062-a0b7-d52005c3aa74)"
+    )
+    return f"🏠 {application_info}\n\nPlease note that you'll need to have your documents ready when applying. For listing and application questions, please contact the Leasing Agent displayed on the listing."
+
+def is_housing_related(question: str) -> bool:
+    """
+    Checks if the question is related to housing.
+    """
+    housing_keywords = ["listings", "housing", "apartments", "rentals", "home", "properties", "houses", "rent"]
+    return any(keyword in question.lower() for keyword in housing_keywords)
+
+def get_housing_response(question: str) -> str:
+    """
+    Returns the appropriate response for housing-related queries.
+    """
+    if "apply" in question.lower() or "application" in question.lower():
+        return format_application_response()
+    return "I can help you find housing options. Would you like to see available listings or learn about the application process?" 

--- a/python-llm-service/rag_utils.py
+++ b/python-llm-service/rag_utils.py
@@ -1,12 +1,17 @@
 # rag_utils.py
 
 from listings import get_live_housing_listings, format_listings
+from application import get_housing_response
 
 def get_context(question: str) -> str:
     """
     Processes the user's question and returns the appropriate response.
     """
     question = question.lower().strip()
+
+    # Check for application-related queries first
+    if "apply" in question or "application" in question:
+        return get_housing_response(question)
 
     # Respond to listing requests
     if "listings" in question:


### PR DESCRIPTION
# Add Application Link Feature to Chatbot

## Changes
- Added new `application.py` file to handle application-related queries
- Implemented clickable application link using Markdown formatting
- Integrated application handling into `rag_utils.py`

## Technical Details
- New `application.py` contains functions for handling application queries and formatting responses
- Application link is formatted as `[Apply for Housing](URL)` in the response
- Frontend renders this as a clickable link with proper styling

## Testing
To test:
1. Ask "How do I apply for housing?"
2. Verify response shows a clickable "Apply for Housing" link
3. Click link to confirm it opens in a new tab

