### PR TITLE
feat(chatbot): implement double-turn logic

### DIFF
--- a/api/src/chatbot/chatbot.controller.ts
+++ b/api/src/chatbot/chatbot.controller.ts
@@ -1,12 +1,20 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { ChatbotService } from './chatbot.service';
 
+interface ChatRequest {
+  message: string;
+  history: Array<{
+    role: 'user' | 'assistant';
+    content: string;
+  }>;
+}
+
 @Controller('chatbot')
 export class ChatbotController {
   constructor(private readonly chatbotService: ChatbotService) {}
 
   @Post()
-  async handleChat(@Body('message') message: string) {
-    return this.chatbotService.forwardToPython(message);
+  async handleChat(@Body() request: ChatRequest) {
+    return this.chatbotService.forwardToPython(request.message, request.history);
   }
 }

--- a/api/src/chatbot/chatbot.service.ts
+++ b/api/src/chatbot/chatbot.service.ts
@@ -1,41 +1,50 @@
 import { Injectable } from '@nestjs/common';
 import axios from 'axios';
 
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
 @Injectable()
 export class ChatbotService {
-  async forwardToPython(message: string) {
+  async forwardToPython(message: string, history: Message[] = []) {
     const lower = message.toLowerCase();
     console.log("🟡 Incoming message:", lower);
+    console.log("📜 Conversation history:", history);
 
     const disclaimer =
       "\n\n⚠️ *This chatbot is an experimental tool. Please verify all information with official housing resources before making decisions.*";
+
+    // Only show disclaimer in first message
+    const shouldShowDisclaimer = history.length === 0;
 
     // 🔒 Static Responses
     if (lower.includes('hello') || lower.includes('hi')) {
       console.log("💬 Matched static greeting");
       return {
-        response: "👋 Hello! I'm Bloom Assist — your guide to affordable housing listings in the Bay Area." + disclaimer,
+        response: "👋 Hello! I'm Bloom Assist — your guide to affordable housing listings in the Bay Area." + (shouldShowDisclaimer ? disclaimer : ""),
       };
     }
 
     if (lower.includes('what do you do') || lower.includes('your job')) {
       console.log("💬 Matched static explanation");
       return {
-        response: "🏡 I help you find available housing listings by connecting directly to Bloom Housing's system." + disclaimer,
+        response: "🏡 I help you find available housing listings by connecting directly to Bloom Housing's system." + (shouldShowDisclaimer ? disclaimer : ""),
       };
     }
 
     if (lower.includes('bye')) {
       console.log("💬 Matched static goodbye");
       return {
-        response: "👋 Thanks for stopping by!\n\n🔗 [Visit Bloom Housing](https://housingbayarea.org/)" + disclaimer,
+        response: "👋 Thanks for stopping by!\n\n🔗 [Visit Bloom Housing](https://housingbayarea.org/)" + (shouldShowDisclaimer ? disclaimer : ""),
       };
     }
 
     if (lower.includes('thanks') || lower.includes('thank you')) {
       console.log("💬 Matched static thanks");
       return {
-        response: "😊 You're very welcome! Let me know if you have any more housing questions." + disclaimer,
+        response: "😊 You're very welcome! Let me know if you have any more housing questions." + (shouldShowDisclaimer ? disclaimer : ""),
       };
     }
 
@@ -45,20 +54,23 @@ export class ChatbotService {
     try {
       const response = await axios.post(
         process.env.PYTHON_API_URL || 'http://localhost:8000/generate',
-        { message }
+        { 
+          message,
+          history // Pass conversation history to Python service
+        }
       );
 
       console.log("✅ Response from Python API:", response.data);
 
-      // Append disclaimer to dynamic responses too
+      // Only append disclaimer to first message
       return {
-        response: response.data.response + disclaimer,
+        response: response.data.response + (shouldShowDisclaimer ? disclaimer : ""),
       };
     } catch (error) {
       console.error("❌ Error calling Python API:", error.message);
 
       return {
-        response: "Sorry, I couldn't reach the housing database. Please try again later." + disclaimer,
+        response: "Sorry, I couldn't reach the housing database. Please try again later." + (shouldShowDisclaimer ? disclaimer : ""),
       };
     }
   }

--- a/python-llm-service/app.py
+++ b/python-llm-service/app.py
@@ -1,6 +1,16 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from rag_utils import get_context
+from typing import List, Optional
+from pydantic import BaseModel
+
+class Message(BaseModel):
+    role: str
+    content: str
+
+class ChatRequest(BaseModel):
+    message: str
+    history: Optional[List[Message]] = []
 
 app = FastAPI()
 
@@ -12,14 +22,15 @@ app.add_middleware(
 )
 
 @app.post("/generate") 
-async def generate_response(request: Request):
-    data = await request.json()
-    message = data.get("message", "")
+async def generate_response(request: ChatRequest):
+    message = request.message
+    history = request.history
 
     print("📩 Received from NestJS:", message)
+    print("📜 Conversation history:", history)
 
-    # Get context using your RAG logic
-    context = get_context(message)
+    # Get context using your RAG logic, now with conversation history
+    context = get_context(message, history)
 
     if context:
         print(f"✅ Context generated (length: {len(context)} chars)")

--- a/python-llm-service/rag_utils.py
+++ b/python-llm-service/rag_utils.py
@@ -2,19 +2,38 @@
 
 from listings import get_live_housing_listings, format_listings
 from application import get_housing_response
+from typing import List, Optional
 
-def get_context(question: str) -> str:
+class Message:
+    def __init__(self, role: str, content: str):
+        self.role = role
+        self.content = content
+
+def get_context(question: str, history: Optional[List[Message]] = None) -> str:
     """
     Processes the user's question and returns the appropriate response.
+    Takes into account conversation history for context-aware responses.
     """
     question = question.lower().strip()
+    history = history or []
+
+    # Check if this is a follow-up question about applications
+    if history and any("apply" in msg.content.lower() or "application" in msg.content.lower() for msg in history):
+        if "how" in question or "what" in question or "where" in question:
+            return get_housing_response(question)
 
     # Check for application-related queries first
     if "apply" in question or "application" in question:
         return get_housing_response(question)
 
+    # Check if this is a follow-up question about listings
+    if history and any("listings" in msg.content.lower() for msg in history):
+        if "more" in question or "another" in question or "other" in question:
+            listings = get_live_housing_listings()
+            return format_listings(listings)
+
     # Respond to listing requests
-    if "listings" in question:
+    if "listings" in question or "show" in question or "available" in question:
         listings = get_live_housing_listings()
         return format_listings(listings)
 

--- a/sites/chatbot/components/ChatBox.module.scss
+++ b/sites/chatbot/components/ChatBox.module.scss
@@ -8,6 +8,9 @@ $link-color: #0066cc;
 $font-family: "Inter", sans-serif;
 $border-radius: 3px;
 $box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
+$link-bg: #e6f3ff;  // Light blue background for links
+$link-border: #0077da;  // Blue border for links
+$text-color: #000000;  // Pure black for regular text
 
 // Main container for the chatbot
 .chatboxContainer {
@@ -121,6 +124,51 @@ $box-shadow: 0 8px 20px rgba(0, 0, 0, 0.2);
   overflow-y: auto;
   margin-bottom: 0.5rem;
   border-radius: $border-radius;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  color: #000000;  // Set base text color for all chat content
+}
+
+// Message styles
+.message {
+  padding: 1rem;
+  border-radius: $border-radius;
+  font-size: 16px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  max-width: 80%;
+  line-height: 1.5;
+
+  p {
+    margin: 0 0 0.5rem 0;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  a {
+    color: $link-color;
+    text-decoration: none;
+  }
+}
+
+.userMessage {
+  background-color: $white;
+  color: $primary-color;
+  align-self: flex-end;
+  border: 1px solid $light-gray;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.assistantMessage {
+  background-color: $white;
+  color: $primary-color;
+  align-self: flex-start;
+  border: 1px solid $light-gray;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 // Form (input + button)


### PR DESCRIPTION
Double Turn ChatBot Implementation

- Added double-turn conversation structure to the chatbot.
- User can ask a question, receive a response, and continue with follow-up questions.
- Limited conversation memory to 10 messages (5 user messages, 5 bot responses).
- Added conversation reset prompt when message limit is reached.
- Prepared chatbot for future AMI (RAG) and LLM integration."
